### PR TITLE
Finalize order flow and receipt page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import PlateBuilder from "./pages/PlateBuilder";
 import OrderTracking from "./pages/OrderTracking";
 import OrderHistory from "./pages/OrderHistory";
 import Profile from "./pages/Profile";
+import Receipt from "./pages/Receipt";
 import AdminLogin from "./pages/admin/AdminLogin";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import OrderManagement from "./pages/admin/OrderManagement";
@@ -32,6 +33,7 @@ const App = () => (
           <Route path="/dashboard" element={<CustomerDashboard />} />
           <Route path="/plate-builder" element={<PlateBuilder />} />
           <Route path="/tracking" element={<OrderTracking />} />
+          <Route path="/receipt" element={<Receipt />} />
           <Route path="/history" element={<OrderHistory />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/admin" element={<AdminLogin />} />

--- a/src/pages/CustomerDashboard.tsx
+++ b/src/pages/CustomerDashboard.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Leaf, ChefHat, Clock, History, User, Bell, Plus } from "lucide-react";
+import { Leaf, ChefHat, Clock, History, Bell, Plus } from "lucide-react";
 import CustomerNavbar from "@/components/CustomerNavbar";
 const CustomerDashboard = () => {
   const navigate = useNavigate();
@@ -37,12 +37,13 @@ const CustomerDashboard = () => {
               <p className="text-xs text-vergreen-600">Fresh & Healthy</p>
             </div>
           </div>
-          <div className="flex items-center space-x-2">
-            <Button variant="ghost" size="sm" className="text-vergreen-600 hover:text-vergreen-700">
+          <div className="flex items-center">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-vergreen-600 hover:text-vergreen-700"
+            >
               <Bell className="w-5 h-5" />
-            </Button>
-            <Button variant="ghost" size="sm" className="text-vergreen-600 hover:text-vergreen-700">
-              <User className="w-5 h-5" />
             </Button>
           </div>
         </div>

--- a/src/pages/PlateBuilder.tsx
+++ b/src/pages/PlateBuilder.tsx
@@ -45,6 +45,11 @@ const PlateBuilder = () => {
     }
   }, [selections.barType, currentStep]);
 
+  // Reset base and sauces when bar type changes
+  useEffect(() => {
+    setSelections(prev => ({ ...prev, base: null, sauces: [] }));
+  }, [selections.barType]);
+
   // Auto-progress when base is selected
   useEffect(() => {
     if (currentStep === 2 && selections.base) {
@@ -63,7 +68,7 @@ const PlateBuilder = () => {
         { id: 'lentils', name: 'Lentils', price: 3.50, icon: '🌾' },
         { id: 'lettuce', name: 'Lettuce', price: 2.50, icon: '🥬' },
         { id: 'quinoa', name: 'Quinoa', price: 4.00, icon: '🌾' },
-        { id: 'pasta-cold', name: 'Cold Pasta', price: 3.50, icon: '🍝' }
+        { id: 'pasta', name: 'Pasta', price: 3.50, icon: '🍝' }
       ];
     } else if (selections.barType?.id === 'pasta') {
       return [
@@ -91,8 +96,7 @@ const PlateBuilder = () => {
       return [
         { id: 'tomato', name: 'Tomato Sauce', price: 0.75, icon: '🍅' },
         { id: 'hot-tomato', name: 'Hot Tomato', price: 1.00, icon: '🌶️' },
-        { id: 'white-sauce', name: 'White Sauce', price: 1.00, icon: '🥛' },
-        { id: 'pesto-pasta', name: 'Pesto', price: 1.25, icon: '🌿' }
+        { id: 'white-sauce', name: 'White Sauce', price: 1.00, icon: '🥛' }
       ];
     }
     return [];
@@ -153,11 +157,19 @@ const PlateBuilder = () => {
       setCurrentStep(currentStep + 1);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     } else {
+      const orderTime = new Date().toLocaleString();
       toast({
         title: "Order placed successfully! 🎉",
         description: `Your ${selections.barType?.name} plate is being prepared. Total: $${calculateTotal()}`,
       });
-      navigate('/tracking');
+      navigate('/receipt', {
+        state: {
+          selections,
+          total: calculateTotal(),
+          orderTime,
+          code: 'VG24'
+        }
+      });
     }
   };
 

--- a/src/pages/Receipt.tsx
+++ b/src/pages/Receipt.tsx
@@ -1,0 +1,82 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import CustomerNavbar from '@/components/CustomerNavbar';
+
+const Receipt = () => {
+  const navigate = useNavigate();
+  const { state } = useLocation() as { state?: Record<string, unknown> };
+  const order = state ?? {};
+
+  if (!order.selections) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>No order found.</p>
+      </div>
+    );
+  }
+
+  const { selections, total, orderTime, code } = order as {
+    selections: Record<string, unknown>;
+    total: string;
+    orderTime: string;
+    code: string;
+  };
+  const typedSelections = selections as Record<string, {id:string; name:string; price:number}[]>;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-vergreen-50 to-emerald-50 pb-20">
+      <div className="bg-white/80 backdrop-blur-sm border-b border-vergreen-100 sticky top-0 z-10">
+        <div className="max-w-md mx-auto px-4 py-4 flex items-center justify-between">
+          <div className="w-16" />
+          <h1 className="font-bold text-vergreen-800">Order Receipt</h1>
+          <div className="w-16" />
+        </div>
+      </div>
+
+      <div className="max-w-md mx-auto p-4 space-y-6">
+        <Card className="bg-white rounded-3xl neumorphic p-6 space-y-4">
+          <div className="text-center space-y-1">
+            <h2 className="text-lg font-bold text-vergreen-800">Thank you!</h2>
+            <p className="text-sm text-vergreen-600">{orderTime}</p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="font-medium text-vergreen-800">{selections.barType?.name}</p>
+            {selections.base && (
+              <div className="flex justify-between text-sm">
+                <span>Base: {selections.base.name}</span>
+                <span>${selections.base.price}</span>
+              </div>
+            )}
+            {['proteins','fibers','cheese','sauces'].map(cat => (
+              typedSelections[cat]?.map((item: {id:string; name:string; price:number}) => (
+                <div key={item.id} className="flex justify-between text-sm">
+                  <span>{item.name}</span>
+                  <span>${item.price}</span>
+                </div>
+              ))
+            ))}
+            <div className="border-t border-vergreen-200 pt-2 flex justify-between font-bold">
+              <span>Total</span>
+              <span>${total}</span>
+            </div>
+          </div>
+
+          <div className="text-center pt-4 space-y-2">
+            <div className="text-4xl font-bold text-vergreen-700">{code}</div>
+            <p className="text-sm text-vergreen-600">Show this when collecting your order</p>
+          </div>
+        </Card>
+
+        <Button className="w-full bg-vergreen-600 hover:bg-vergreen-700 text-white rounded-2xl" onClick={() => navigate('/tracking')}>
+          Track Order
+        </Button>
+      </div>
+
+      <CustomerNavbar />
+    </div>
+  );
+};
+
+export default Receipt;


### PR DESCRIPTION
## Summary
- remove duplicate user icon from dashboard header
- reset base and sauces when bar type changes
- create order receipt page and navigate there after placing order
- wire up new route in `App.tsx`
- adjust pasta options

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type and @typescript-eslint/no-require-imports in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684211efae84832184b540a89ce06ce1