### PR TITLE
Finalize order flow and add admin dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Index from "./pages/Index";
 import AuthPage from "./pages/AuthPage";
 import CustomerDashboard from "./pages/CustomerDashboard";
@@ -11,11 +11,13 @@ import PlateBuilder from "./pages/PlateBuilder";
 import OrderTracking from "./pages/OrderTracking";
 import OrderHistory from "./pages/OrderHistory";
 import Profile from "./pages/Profile";
+import Receipt from "./pages/Receipt";
 import AdminLogin from "./pages/admin/AdminLogin";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import OrderManagement from "./pages/admin/OrderManagement";
 import InventoryManagement from "./pages/admin/InventoryManagement";
 import Analytics from "./pages/admin/Analytics";
+import AdminLayout from "./layouts/AdminLayout";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -32,13 +34,17 @@ const App = () => (
           <Route path="/dashboard" element={<CustomerDashboard />} />
           <Route path="/plate-builder" element={<PlateBuilder />} />
           <Route path="/tracking" element={<OrderTracking />} />
+          <Route path="/receipt" element={<Receipt />} />
           <Route path="/history" element={<OrderHistory />} />
           <Route path="/profile" element={<Profile />} />
-          <Route path="/admin" element={<AdminLogin />} />
-          <Route path="/admin/dashboard" element={<AdminDashboard />} />
-          <Route path="/admin/orders" element={<OrderManagement />} />
-          <Route path="/admin/inventory" element={<InventoryManagement />} />
-          <Route path="/admin/analytics" element={<Analytics />} />
+          <Route path="/admin/login" element={<AdminLogin />} />
+          <Route path="/admin" element={<AdminLayout />}>
+            <Route index element={<Navigate to="dashboard" replace />} />
+            <Route path="dashboard" element={<AdminDashboard />} />
+            <Route path="orders" element={<OrderManagement />} />
+            <Route path="inventory" element={<InventoryManagement />} />
+            <Route path="analytics" element={<Analytics />} />
+          </Route>
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,0 +1,63 @@
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import AdminNavbar from "@/components/AdminNavbar";
+import {
+  Home,
+  Package,
+  BarChart3,
+  PieChart,
+  LogOut,
+} from "lucide-react";
+
+const AdminLayout = () => {
+  const navigate = useNavigate();
+  const navItems = [
+    { label: "Dashboard", icon: Home, path: "/admin/dashboard" },
+    { label: "Orders", icon: Package, path: "/admin/orders" },
+    { label: "Inventory", icon: BarChart3, path: "/admin/inventory" },
+    { label: "Analytics", icon: PieChart, path: "/admin/analytics" },
+  ];
+
+  return (
+    <div className="min-h-screen flex bg-vergreen-50">
+      {/* Sidebar */}
+      <aside className="hidden md:flex md:flex-col w-56 p-4 bg-white border-r border-vergreen-100">
+        <div className="mb-8 px-2 text-xl font-bold text-vergreen-700">VerGreen</div>
+        <nav className="flex-1 space-y-2">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                className={({ isActive }) =>
+                  `flex items-center space-x-3 px-3 py-2 rounded-xl text-sm font-medium hover:bg-vergreen-100 ${
+                    isActive ? "bg-vergreen-100 text-vergreen-700" : "text-gray-600"
+                  }`
+                }
+              >
+                <Icon className="w-4 h-4" />
+                <span>{item.label}</span>
+              </NavLink>
+            );
+          })}
+        </nav>
+        <button
+          onClick={() => navigate("/admin/login")}
+          className="mt-auto flex items-center space-x-3 px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-xl"
+        >
+          <LogOut className="w-4 h-4" />
+          <span>Logout</span>
+        </button>
+      </aside>
+
+      <div className="flex-1 min-h-screen flex flex-col">
+        <div className="flex-1">
+          <Outlet />
+        </div>
+        <AdminNavbar />
+      </div>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/src/pages/CustomerDashboard.tsx
+++ b/src/pages/CustomerDashboard.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Leaf, ChefHat, Clock, History, User, Bell, Plus } from "lucide-react";
+import { Leaf, ChefHat, Clock, History, Bell, Plus } from "lucide-react";
 import CustomerNavbar from "@/components/CustomerNavbar";
 const CustomerDashboard = () => {
   const navigate = useNavigate();
@@ -37,12 +37,13 @@ const CustomerDashboard = () => {
               <p className="text-xs text-vergreen-600">Fresh & Healthy</p>
             </div>
           </div>
-          <div className="flex items-center space-x-2">
-            <Button variant="ghost" size="sm" className="text-vergreen-600 hover:text-vergreen-700">
+          <div className="flex items-center">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-vergreen-600 hover:text-vergreen-700"
+            >
               <Bell className="w-5 h-5" />
-            </Button>
-            <Button variant="ghost" size="sm" className="text-vergreen-600 hover:text-vergreen-700">
-              <User className="w-5 h-5" />
             </Button>
           </div>
         </div>

--- a/src/pages/PlateBuilder.tsx
+++ b/src/pages/PlateBuilder.tsx
@@ -45,6 +45,11 @@ const PlateBuilder = () => {
     }
   }, [selections.barType, currentStep]);
 
+  // Reset base and sauces when bar type changes
+  useEffect(() => {
+    setSelections(prev => ({ ...prev, base: null, sauces: [] }));
+  }, [selections.barType]);
+
   // Auto-progress when base is selected
   useEffect(() => {
     if (currentStep === 2 && selections.base) {
@@ -63,7 +68,7 @@ const PlateBuilder = () => {
         { id: 'lentils', name: 'Lentils', price: 3.50, icon: '🌾' },
         { id: 'lettuce', name: 'Lettuce', price: 2.50, icon: '🥬' },
         { id: 'quinoa', name: 'Quinoa', price: 4.00, icon: '🌾' },
-        { id: 'pasta-cold', name: 'Cold Pasta', price: 3.50, icon: '🍝' }
+        { id: 'pasta', name: 'Pasta', price: 3.50, icon: '🍝' }
       ];
     } else if (selections.barType?.id === 'pasta') {
       return [
@@ -91,8 +96,7 @@ const PlateBuilder = () => {
       return [
         { id: 'tomato', name: 'Tomato Sauce', price: 0.75, icon: '🍅' },
         { id: 'hot-tomato', name: 'Hot Tomato', price: 1.00, icon: '🌶️' },
-        { id: 'white-sauce', name: 'White Sauce', price: 1.00, icon: '🥛' },
-        { id: 'pesto-pasta', name: 'Pesto', price: 1.25, icon: '🌿' }
+        { id: 'white-sauce', name: 'White Sauce', price: 1.00, icon: '🥛' }
       ];
     }
     return [];
@@ -153,11 +157,19 @@ const PlateBuilder = () => {
       setCurrentStep(currentStep + 1);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     } else {
+      const orderTime = new Date().toLocaleString();
       toast({
         title: "Order placed successfully! 🎉",
         description: `Your ${selections.barType?.name} plate is being prepared. Total: $${calculateTotal()}`,
       });
-      navigate('/tracking');
+      navigate('/receipt', {
+        state: {
+          selections,
+          total: calculateTotal(),
+          orderTime,
+          code: 'VG24'
+        }
+      });
     }
   };
 

--- a/src/pages/Receipt.tsx
+++ b/src/pages/Receipt.tsx
@@ -1,0 +1,82 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import CustomerNavbar from '@/components/CustomerNavbar';
+
+const Receipt = () => {
+  const navigate = useNavigate();
+  const { state } = useLocation() as { state?: Record<string, unknown> };
+  const order = state ?? {};
+
+  if (!order.selections) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>No order found.</p>
+      </div>
+    );
+  }
+
+  const { selections, total, orderTime, code } = order as {
+    selections: Record<string, unknown>;
+    total: string;
+    orderTime: string;
+    code: string;
+  };
+  const typedSelections = selections as Record<string, {id:string; name:string; price:number}[]>;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-vergreen-50 to-emerald-50 pb-20">
+      <div className="bg-white/80 backdrop-blur-sm border-b border-vergreen-100 sticky top-0 z-10">
+        <div className="max-w-md mx-auto px-4 py-4 flex items-center justify-between">
+          <div className="w-16" />
+          <h1 className="font-bold text-vergreen-800">Order Receipt</h1>
+          <div className="w-16" />
+        </div>
+      </div>
+
+      <div className="max-w-md mx-auto p-4 space-y-6">
+        <Card className="bg-white rounded-3xl neumorphic p-6 space-y-4">
+          <div className="text-center space-y-1">
+            <h2 className="text-lg font-bold text-vergreen-800">Thank you!</h2>
+            <p className="text-sm text-vergreen-600">{orderTime}</p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="font-medium text-vergreen-800">{selections.barType?.name}</p>
+            {selections.base && (
+              <div className="flex justify-between text-sm">
+                <span>Base: {selections.base.name}</span>
+                <span>${selections.base.price}</span>
+              </div>
+            )}
+            {['proteins','fibers','cheese','sauces'].map(cat => (
+              typedSelections[cat]?.map((item: {id:string; name:string; price:number}) => (
+                <div key={item.id} className="flex justify-between text-sm">
+                  <span>{item.name}</span>
+                  <span>${item.price}</span>
+                </div>
+              ))
+            ))}
+            <div className="border-t border-vergreen-200 pt-2 flex justify-between font-bold">
+              <span>Total</span>
+              <span>${total}</span>
+            </div>
+          </div>
+
+          <div className="text-center pt-4 space-y-2">
+            <div className="text-4xl font-bold text-vergreen-700">{code}</div>
+            <p className="text-sm text-vergreen-600">Show this when collecting your order</p>
+          </div>
+        </Card>
+
+        <Button className="w-full bg-vergreen-600 hover:bg-vergreen-700 text-white rounded-2xl" onClick={() => navigate('/tracking')}>
+          Track Order
+        </Button>
+      </div>
+
+      <CustomerNavbar />
+    </div>
+  );
+};
+
+export default Receipt;

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -13,40 +13,29 @@ import {
   LogOut,
   Leaf
 } from "lucide-react";
-import AdminNavbar from "@/components/AdminNavbar";
 
 const AdminDashboard = () => {
   const navigate = useNavigate();
 
   const kpis = [
     {
-      title: "Orders Today",
+      title: "Total Orders Today",
       value: "47",
-      change: "+12%",
       icon: Package,
-      color: "text-blue-600"
+      color: "text-blue-600",
+    },
+    {
+      title: "Average Prep Time",
+      value: "14m",
+      icon: TrendingUp,
+      color: "text-purple-600",
     },
     {
       title: "Orders/Hour",
       value: "6.2",
-      change: "+8%",
       icon: Clock,
-      color: "text-vergreen-600"
+      color: "text-vergreen-600",
     },
-    {
-      title: "Queue Size",
-      value: "8",
-      change: "-3",
-      icon: Users,
-      color: "text-orange-600"
-    },
-    {
-      title: "Avg Prep Time",
-      value: "14m",
-      change: "-2m",
-      icon: TrendingUp,
-      color: "text-purple-600"
-    }
   ];
 
   const quickActions = [
@@ -74,9 +63,9 @@ const AdminDashboard = () => {
   ];
 
   const recentOrders = [
-    { id: "VG-001", customer: "Alex Johnson", status: "Preparing", time: "2m ago" },
-    { id: "VG-002", customer: "Sarah Wilson", status: "Ready", time: "5m ago" },
-    { id: "VG-003", customer: "Mike Chen", status: "Validated", time: "7m ago" },
+    { id: "VG-001", time: "10:05", status: "Preparing", total: 12.5 },
+    { id: "VG-002", time: "10:15", status: "Ready", total: 11.25 },
+    { id: "VG-003", time: "10:25", status: "Validated", total: 10.75 },
   ];
 
   return (
@@ -119,7 +108,7 @@ const AdminDashboard = () => {
         </div>
 
         {/* KPIs Grid */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {kpis.map((kpi, index) => (
             <Card key={index} className="bg-white rounded-3xl neumorphic p-6 text-center">
               <div className={`w-12 h-12 ${kpi.color} bg-opacity-10 rounded-2xl mx-auto mb-3 flex items-center justify-center`}>
@@ -130,9 +119,6 @@ const AdminDashboard = () => {
               </div>
               <div className="text-sm text-vergreen-600 mb-1">
                 {kpi.title}
-              </div>
-              <div className="text-xs text-vergreen-500">
-                {kpi.change}
               </div>
             </Card>
           ))}
@@ -166,36 +152,46 @@ const AdminDashboard = () => {
           </div>
         </div>
 
-        {/* Recent Orders */}
+        {/* Today's Orders */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <Card className="bg-white rounded-3xl neumorphic p-6">
+          <Card className="bg-white rounded-3xl neumorphic p-6 overflow-x-auto">
             <h3 className="text-lg font-semibold text-vergreen-800 mb-4">
-              Recent Orders
+              Today's Orders
             </h3>
-            <div className="space-y-3">
-              {recentOrders.map((order, index) => (
-                <div key={index} className="flex items-center justify-between p-3 bg-vergreen-50 rounded-2xl">
-                  <div>
-                    <div className="font-medium text-vergreen-800">{order.id}</div>
-                    <div className="text-sm text-vergreen-600">{order.customer}</div>
-                  </div>
-                  <div className="text-right">
-                    <div className={`text-sm font-medium px-2 py-1 rounded-lg ${
-                      order.status === 'Ready' 
-                        ? 'bg-green-100 text-green-800'
-                        : order.status === 'Preparing'
-                        ? 'bg-orange-100 text-orange-800'
-                        : 'bg-blue-100 text-blue-800'
-                    }`}>
-                      {order.status}
-                    </div>
-                    <div className="text-xs text-vergreen-500 mt-1">{order.time}</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            <Button 
-              variant="outline" 
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-vergreen-100 text-vergreen-600">
+                  <th className="px-3 py-2 text-left font-medium">Order ID</th>
+                  <th className="px-3 py-2 text-left font-medium">Time</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 text-right font-medium">Total</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-vergreen-100">
+                {recentOrders.map((order) => (
+                  <tr key={order.id}>
+                    <td className="px-3 py-2 whitespace-nowrap">{order.id}</td>
+                    <td className="px-3 py-2 whitespace-nowrap">{order.time}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`px-2 py-1 rounded-lg text-xs font-medium ${
+                          order.status === 'Ready'
+                            ? 'bg-green-100 text-green-800'
+                            : order.status === 'Preparing'
+                            ? 'bg-orange-100 text-orange-800'
+                            : 'bg-blue-100 text-blue-800'
+                        }`}
+                      >
+                        {order.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-right">${order.total.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <Button
+              variant="outline"
               className="w-full mt-4 border-vergreen-200 text-vergreen-700 hover:bg-vergreen-50 rounded-2xl"
               onClick={() => navigate('/admin/orders')}
             >
@@ -239,8 +235,6 @@ const AdminDashboard = () => {
         </div>
       </div>
 
-      {/* Bottom Navigation */}
-      <AdminNavbar />
     </div>
   );
 };

--- a/src/pages/admin/Analytics.tsx
+++ b/src/pages/admin/Analytics.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ArrowLeft, TrendingUp, DollarSign, Users, Clock } from "lucide-react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line } from "recharts";
-import AdminNavbar from "@/components/AdminNavbar";
 
 const Analytics = () => {
   const navigate = useNavigate();
@@ -254,8 +253,6 @@ const Analytics = () => {
         </div>
       </div>
 
-      {/* Bottom Navigation */}
-      <AdminNavbar />
     </div>
   );
 };

--- a/src/pages/admin/InventoryManagement.tsx
+++ b/src/pages/admin/InventoryManagement.tsx
@@ -6,34 +6,33 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, Package, AlertTriangle, Plus, Minus } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
-import AdminNavbar from "@/components/AdminNavbar";
 
 const InventoryManagement = () => {
   const navigate = useNavigate();
   const [inventory, setInventory] = useState({
-    bases: [
+    base: [
+      { id: 'rice', name: 'Rice', stock: 20, minStock: 10, icon: '🍚' },
       { id: 'quinoa', name: 'Quinoa', stock: 15, minStock: 10, icon: '🌾' },
-      { id: 'rice', name: 'Brown Rice', stock: 8, minStock: 12, icon: '🍚' },
-      { id: 'pasta', name: 'Whole Wheat Pasta', stock: 20, minStock: 8, icon: '🍝' },
-      { id: 'salad', name: 'Mixed Greens', stock: 25, minStock: 15, icon: '🥗' }
+      { id: 'pasta', name: 'Pasta', stock: 18, minStock: 8, icon: '🍝' }
     ],
     proteins: [
-      { id: 'chicken', name: 'Grilled Chicken', stock: 12, minStock: 10, icon: '🍗' },
-      { id: 'salmon', name: 'Grilled Salmon', stock: 6, minStock: 8, icon: '🐟' },
-      { id: 'tofu', name: 'Marinated Tofu', stock: 18, minStock: 10, icon: '🧈' },
-      { id: 'beans', name: 'Black Beans', stock: 30, minStock: 15, icon: '🫘' }
+      { id: 'chicken', name: 'Chicken', stock: 12, minStock: 10, icon: '🍗' },
+      { id: 'tuna', name: 'Tuna', stock: 9, minStock: 8, icon: '🐟' },
+      { id: 'shrimp', name: 'Shrimp', stock: 6, minStock: 6, icon: '🦐' }
     ],
-    vegetables: [
-      { id: 'broccoli', name: 'Steamed Broccoli', stock: 22, minStock: 15, icon: '🥦' },
-      { id: 'carrots', name: 'Roasted Carrots', stock: 16, minStock: 12, icon: '🥕' },
-      { id: 'peppers', name: 'Bell Peppers', stock: 14, minStock: 10, icon: '🫑' },
-      { id: 'tomatoes', name: 'Cherry Tomatoes', stock: 5, minStock: 12, icon: '🍅' }
+    veggies: [
+      { id: 'spinach', name: 'Spinach', stock: 22, minStock: 15, icon: '🥬' },
+      { id: 'carrots', name: 'Carrots', stock: 16, minStock: 12, icon: '🥕' },
+      { id: 'tomatoes', name: 'Tomatoes', stock: 5, minStock: 10, icon: '🍅' }
     ],
-    extras: [
-      { id: 'avocado', name: 'Fresh Avocado', stock: 3, minStock: 8, icon: '🥑' },
-      { id: 'feta', name: 'Feta Cheese', stock: 5, minStock: 10, icon: '🧀' },
-      { id: 'nuts', name: 'Mixed Nuts', stock: 25, minStock: 15, icon: '🥜' },
-      { id: 'seeds', name: 'Pumpkin Seeds', stock: 18, minStock: 12, icon: '🌱' }
+    cheese: [
+      { id: 'mozz', name: 'Mozzarella', stock: 8, minStock: 6, icon: '🧀' },
+      { id: 'sicilian', name: 'Sicilian', stock: 4, minStock: 6, icon: '🧀' }
+    ],
+    sauces: [
+      { id: 'pesto', name: 'Pesto', stock: 10, minStock: 8, icon: '🫙' },
+      { id: 'tomato', name: 'Tomato', stock: 14, minStock: 10, icon: '🍅' },
+      { id: 'caesar', name: 'Caesar', stock: 6, minStock: 6, icon: '🥣' }
     ]
   });
 
@@ -230,8 +229,6 @@ const InventoryManagement = () => {
         </div>
       </div>
 
-      {/* Bottom Navigation */}
-      <AdminNavbar />
     </div>
   );
 };

--- a/src/pages/admin/OrderManagement.tsx
+++ b/src/pages/admin/OrderManagement.tsx
@@ -5,60 +5,55 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { ArrowLeft, Clock, Filter, Search, MoreVertical } from "lucide-react";
+import { ArrowLeft, Filter, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import AdminNavbar from "@/components/AdminNavbar";
 
 const OrderManagement = () => {
   const navigate = useNavigate();
-  const [filter, setFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [dateFilter, setDateFilter] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
 
   const orders = [
     {
       id: "VG-2024-001",
       customer: "Alex Johnson",
-      items: ["Mediterranean Power Bowl", "Tahini Dressing"],
       status: "Preparing",
-      time: "12:30 PM",
-      total: 14.50,
-      estimatedTime: "8 min"
+      date: "2025-06-05",
+      time: "12:30",
+      total: 14.5,
     },
     {
       id: "VG-2024-002",
       customer: "Sarah Wilson",
-      items: ["Asian Fusion Bowl", "Teriyaki Sauce"],
       status: "Ready",
-      time: "12:25 PM",
+      date: "2025-06-05",
+      time: "12:25",
       total: 13.25,
-      estimatedTime: "Ready"
     },
     {
       id: "VG-2024-003",
       customer: "Mike Chen",
-      items: ["Green Goddess Salad", "Balsamic Glaze"],
       status: "Validated",
-      time: "12:35 PM",
+      date: "2025-06-05",
+      time: "12:35",
       total: 12.75,
-      estimatedTime: "12 min"
     },
     {
       id: "VG-2024-004",
       customer: "Emma Davis",
-      items: ["Protein Power Pasta", "Pesto Sauce"],
       status: "Submitted",
-      time: "12:40 PM",
-      total: 15.00,
-      estimatedTime: "15 min"
+      date: "2025-06-05",
+      time: "12:40",
+      total: 15,
     },
     {
       id: "VG-2024-005",
       customer: "Tom Brown",
-      items: ["Vegan Paradise Bowl", "Olive Oil Dressing"],
       status: "Preparing",
-      time: "12:28 PM",
-      total: 11.50,
-      estimatedTime: "6 min"
+      date: "2025-06-05",
+      time: "12:28",
+      total: 11.5,
     }
   ];
 
@@ -82,10 +77,20 @@ const OrderManagement = () => {
     // Here you would update the order in your state management
   };
 
-  const filteredOrders = orders.filter(order => {
-    if (filter !== "all" && order.status.toLowerCase() !== filter) return false;
-    if (searchTerm && !order.customer.toLowerCase().includes(searchTerm.toLowerCase()) && 
-        !order.id.toLowerCase().includes(searchTerm.toLowerCase())) return false;
+  const filteredOrders = orders.filter((order) => {
+    if (statusFilter !== "all" && order.status.toLowerCase() !== statusFilter) {
+      return false;
+    }
+    if (dateFilter && order.date !== dateFilter) {
+      return false;
+    }
+    if (
+      searchTerm &&
+      !order.customer.toLowerCase().includes(searchTerm.toLowerCase()) &&
+      !order.id.toLowerCase().includes(searchTerm.toLowerCase())
+    ) {
+      return false;
+    }
     return true;
   });
 
@@ -106,7 +111,7 @@ const OrderManagement = () => {
             </Button>
             <h1 className="text-xl font-bold text-vergreen-800">Order Management</h1>
           </div>
-          <div className="flex items-center space-x-3">
+          <div className="flex flex-wrap items-center gap-3">
             <div className="relative">
               <Search className="absolute left-3 top-2.5 h-4 w-4 text-vergreen-500" />
               <Input
@@ -116,10 +121,16 @@ const OrderManagement = () => {
                 className="pl-10 w-64 bg-white border-vergreen-200 rounded-xl focus:ring-vergreen-500"
               />
             </div>
-            <Select value={filter} onValueChange={setFilter}>
+            <Input
+              type="date"
+              value={dateFilter}
+              onChange={(e) => setDateFilter(e.target.value)}
+              className="bg-white border-vergreen-200 rounded-xl px-3 py-2"
+            />
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
               <SelectTrigger className="w-40 bg-white border-vergreen-200 rounded-xl">
                 <Filter className="w-4 h-4 mr-2" />
-                <SelectValue placeholder="Filter" />
+                <SelectValue placeholder="Status" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Orders</SelectItem>
@@ -153,57 +164,37 @@ const OrderManagement = () => {
           ))}
         </div>
 
-        {/* Orders List */}
-        <div className="space-y-4">
-          {filteredOrders.map((order) => (
-            <Card key={order.id} className="bg-white rounded-3xl neumorphic p-6">
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center space-x-4">
-                  <div>
-                    <h3 className="font-semibold text-vergreen-800">{order.id}</h3>
-                    <p className="text-sm text-vergreen-600">{order.customer}</p>
-                  </div>
-                  <Badge className={`${getStatusColor(order.status)} border-0`}>
-                    {order.status}
-                  </Badge>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <div className="text-right">
-                    <div className="font-medium text-vergreen-800">${order.total}</div>
-                    <div className="text-sm text-vergreen-600">{order.time}</div>
-                  </div>
-                  <Button variant="ghost" size="sm" className="text-vergreen-600">
-                    <MoreVertical className="w-4 h-4" />
-                  </Button>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                {/* Order Items */}
-                <div className="lg:col-span-2">
-                  <h4 className="font-medium text-vergreen-800 mb-2">Order Items</h4>
-                  <div className="space-y-1">
-                    {order.items.map((item, index) => (
-                      <p key={index} className="text-sm text-vergreen-600">
-                        • {item}
-                      </p>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Actions */}
-                <div className="space-y-3">
-                  <div className="flex items-center space-x-2">
-                    <Clock className="w-4 h-4 text-vergreen-500" />
-                    <span className="text-sm text-vergreen-700">ETA: {order.estimatedTime}</span>
-                  </div>
-                  
-                  {order.status !== 'Ready' && (
-                    <Select 
-                      value={order.status} 
+        {/* Orders Table */}
+        <Card className="bg-white rounded-3xl neumorphic p-6 overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b border-vergreen-100 text-vergreen-600">
+                <th className="px-3 py-2 text-left font-medium">Order ID</th>
+                <th className="px-3 py-2 text-left font-medium">Customer</th>
+                <th className="px-3 py-2 text-left font-medium">Date</th>
+                <th className="px-3 py-2 text-left font-medium">Time</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 text-right font-medium">Total</th>
+                <th className="px-3 py-2 font-medium">Update</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-vergreen-100">
+              {filteredOrders.map((order) => (
+                <tr key={order.id}>
+                  <td className="px-3 py-2 whitespace-nowrap">{order.id}</td>
+                  <td className="px-3 py-2 whitespace-nowrap">{order.customer}</td>
+                  <td className="px-3 py-2 whitespace-nowrap">{order.date}</td>
+                  <td className="px-3 py-2 whitespace-nowrap">{order.time}</td>
+                  <td className="px-3 py-2">
+                    <Badge className={`${getStatusColor(order.status)} border-0`}>{order.status}</Badge>
+                  </td>
+                  <td className="px-3 py-2 text-right">${order.total.toFixed(2)}</td>
+                  <td className="px-3 py-2">
+                    <Select
+                      value={order.status}
                       onValueChange={(newStatus) => updateOrderStatus(order.id, newStatus)}
                     >
-                      <SelectTrigger className="w-full bg-vergreen-50 border-vergreen-200 rounded-xl">
+                      <SelectTrigger className="w-32 bg-vergreen-50 border-vergreen-200 rounded-xl">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -213,21 +204,12 @@ const OrderManagement = () => {
                         <SelectItem value="Ready">Ready</SelectItem>
                       </SelectContent>
                     </Select>
-                  )}
-
-                  {order.status === 'Ready' && (
-                    <Button 
-                      className="w-full bg-green-600 hover:bg-green-700 text-white rounded-xl"
-                      onClick={() => updateOrderStatus(order.id, 'Completed')}
-                    >
-                      Mark as Picked Up
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </Card>
-          ))}
-        </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
 
         {filteredOrders.length === 0 && (
           <div className="text-center py-12">
@@ -244,8 +226,6 @@ const OrderManagement = () => {
         )}
       </div>
 
-      {/* Bottom Navigation */}
-      <AdminNavbar />
     </div>
   );
 };

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -125,5 +126,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add receipt page and route so orders show pickup code
- implement admin dashboard pages with login, orders, inventory, and analytics
- remove duplicate user icon from dashboard header
- fix lint issues and import tailwindcss-animate without `require`
- add layout component with sidebar nav for admin pages and nest routes
- refine admin dashboard table and mock KPIs
- simplify order management view with table filters
- group inventory items by base, proteins, veggies, cheese, and sauces

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684211efae84832184b540a89ce06ce1